### PR TITLE
Add config object and use it to configure generation

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -22,9 +22,20 @@ still be run if a step raises an exception.
 ### algorithm
 The algorithm used for test generation. Default is RandomAlgorithm.
 
+### tests_in_a_suite
+Integer. Set how many tests will be generated/run in a suite.
+
+### steps_in_a_test
+Integer. Set how many steps will be generated into a single test.
+
 ## APIs in Osmo
 The Osmo object contains the following apis to access the configuration
 object directly:
+
+### config
+Gets the OsmoConfig object. If set to a new OsmoConfig object, linking
+stop_on_fail, stop_test_on_exception, tests_in_a_suite
+and steps_in_a_test is done automatically in the setter.
 
 ### stop_on_fail
 Set the stop_on_fail configuration value.
@@ -32,7 +43,7 @@ Set the stop_on_fail configuration value.
 ### stop_test_on_exception
 Set the stop_test_on_exception configuration value.
 
-### algorithm
+### set_algorithm
 Attribute that points to the algorithm object in the configuration
 
 ### tests_in_a_suite

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,0 +1,42 @@
+# Configuring test generation
+Test generation can be configured using an OsmoConfig object that is
+available in [config.py](pyosmo/config.py). This object is initialized
+as a part of the Osmo object under attribute config. If you want to
+configure test generation, you cana either access
+the configuration through this object, create your own and replace
+the config object or use the api:s available in the Osmo object.
+
+## Available configuration
+The OsmoConfig object contains the following configuration values:
+
+### stop_on_fail
+Boolean. If set to True (default), test suite generation will stop after
+a test that had a failed step has finished. Set to False to continue
+test generation until the end of the test suite has been reached.
+
+### stop_test_on_exception
+Boolean. If set to True (default), a test will stop if a step
+raises an exception. If set to False, other steps in the test will
+still be run if a step raises an exception.
+
+### algorithm
+The algorithm used for test generation. Default is RandomAlgorithm.
+
+## APIs in Osmo
+The Osmo object contains the following apis to access the configuration
+object directly:
+
+### stop_on_fail
+Set the stop_on_fail configuration value.
+
+### stop_test_on_exception
+Set the stop_test_on_exception configuration value.
+
+### algorithm
+Attribute that points to the algorithm object in the configuration
+
+### tests_in_a_suite
+Integer. Set how many tests will be generated/run in a suite.
+
+### steps_in_a_test
+Integer. Set how many steps will be generated into a single test.

--- a/pyosmo/config.py
+++ b/pyosmo/config.py
@@ -5,6 +5,7 @@ class OsmoConfig(object):
     def __init__(self):
         self._stop_on_failure = True
         self._algorithm = RandomAlgorithm()
+        self._stop_test_on_exception = True
 
     @property
     def stop_on_fail(self):
@@ -13,6 +14,14 @@ class OsmoConfig(object):
     @stop_on_fail.setter
     def stop_on_fail(self, value):
         self._stop_on_failure = value
+
+    @property
+    def stop_test_on_exception(self):
+        return self._stop_test_on_exception
+
+    @stop_test_on_exception.setter
+    def stop_test_on_exception(self, value):
+        self._stop_test_on_exception = value
 
     @property
     def algorithm(self):

--- a/pyosmo/config.py
+++ b/pyosmo/config.py
@@ -6,6 +6,8 @@ class OsmoConfig(object):
         self._stop_on_failure = True
         self._algorithm = RandomAlgorithm()
         self._stop_test_on_exception = True
+        self._steps_in_a_test = 1
+        self._tests_in_a_suite = 1
 
     @property
     def stop_on_fail(self):
@@ -30,3 +32,19 @@ class OsmoConfig(object):
     @algorithm.setter
     def algorithm(self, value):
         self._algorithm = value
+
+    @property
+    def steps_in_a_test(self):
+        return self._steps_in_a_test
+
+    @steps_in_a_test.setter
+    def steps_in_a_test(self, value):
+        self._steps_in_a_test = value
+
+    @property
+    def tests_in_a_suite(self):
+        return self._tests_in_a_suite
+
+    @tests_in_a_suite.setter
+    def tests_in_a_suite(self, value):
+        self._tests_in_a_suite = value

--- a/pyosmo/config.py
+++ b/pyosmo/config.py
@@ -1,0 +1,23 @@
+from pyosmo.algorithm.random import RandomAlgorithm
+
+
+class OsmoConfig(object):
+    def __init__(self):
+        self._stop_on_failure = True
+        self._algorithm = RandomAlgorithm()
+
+    @property
+    def stop_on_failure(self):
+        return self._stop_on_failure
+
+    @stop_on_failure.setter
+    def stop_on_failure(self, value):
+        self._stop_on_failure = value
+
+    @property
+    def algorithm(self):
+        return self._algorithm
+
+    @algorithm.setter
+    def algorithm(self, value):
+        self._algorithm = value

--- a/pyosmo/config.py
+++ b/pyosmo/config.py
@@ -7,11 +7,11 @@ class OsmoConfig(object):
         self._algorithm = RandomAlgorithm()
 
     @property
-    def stop_on_failure(self):
+    def stop_on_fail(self):
         return self._stop_on_failure
 
-    @stop_on_failure.setter
-    def stop_on_failure(self, value):
+    @stop_on_fail.setter
+    def stop_on_fail(self, value):
         self._stop_on_failure = value
 
     @property

--- a/pyosmo/osmo.py
+++ b/pyosmo/osmo.py
@@ -2,8 +2,8 @@ import random
 import time
 
 from pyosmo.model import Model
+from pyosmo.config import OsmoConfig
 from pyosmo.history import OsmoHistory
-from pyosmo.algorithm.random import RandomAlgorithm
 
 
 class Osmo(object):
@@ -14,11 +14,14 @@ class Osmo(object):
         self.model = Model()
         self.model.add_model(model)
         self.history = OsmoHistory()
+        self.config = OsmoConfig()
         self.tests_in_a_suite = 10
         self.steps_in_a_test = 10
+        self.current_test_number = 0
+        self.failed_tests = 0
         self.debug = False
         # Use random as default algorithm
-        self.algorithm = RandomAlgorithm()
+        self.algorithm = self.config.algorithm
 
         if seed is None:
             self.seed = random.randint(0, 10000)
@@ -35,6 +38,16 @@ class Osmo(object):
     def set_debug(self, debug):
         self.debug = debug
 
+    def set_algorithm(self, algorithm):
+        """
+        Set algorithm for config osmo.
+
+        :param algorithm: Algorithm object.
+        :return: Nothing
+        """
+        self.config.algorithm = algorithm
+        self.algorithm = algorithm
+
     def add_model(self, model):
         """ Add model for osmo """
         self.model.add_model(model)
@@ -50,6 +63,18 @@ class Osmo(object):
         self.model.execute(step_name)
         self.history.add_step(step_name, time.time() - start_time)
 
+    def should_end_suite(self):
+        """
+        Check if suite should be ended.
+
+        :return: Boolean
+        """
+        if self.current_test_number == self.tests_in_a_suite:
+            return True
+        elif self.config.stop_on_failure and self.failed_tests:
+            return True
+        return False
+
     def generate(self):
         """ Generate / run tests """
 
@@ -60,17 +85,21 @@ class Osmo(object):
         if not self.tests_in_a_suite:
             raise Exception("Empty model!")
 
-        for _ in range(self.tests_in_a_suite):
+        while not self.should_end_suite():
             self.history.start_new_test()
+            self.current_test_number += 1
             self.model.execute_optional('before_test')
-            for _ in range(self.steps_in_a_test):
-                # Use algorithm to select the step
-                ending = self.algorithm.choose(self.history, self.model.get_list_of_available_steps())
-                self.model.execute_optional('pre_{}'.format(ending))
-                self._execute_step(ending)
-                self.model.execute_optional('post_{}'.format(ending))
-                # General after step which is run after each step
-                self.model.execute_optional('after')
+            try:
+                for _ in range(self.steps_in_a_test):
+                    # Use algorithm to select the step
+                    ending = self.algorithm.choose(self.history, self.model.get_list_of_available_steps())
+                    self.model.execute_optional('pre_{}'.format(ending))
+                    self._execute_step(ending)
+                    self.model.execute_optional('post_{}'.format(ending))
+                    # General after step which is run after each step
+                    self.model.execute_optional('after')
+            except Exception:
+                self.failed_tests += 1
             self.model.execute_optional('after_test')
         self.model.execute_optional('after_suite')
         self.history.stop()

--- a/pyosmo/osmo.py
+++ b/pyosmo/osmo.py
@@ -40,13 +40,21 @@ class Osmo(object):
 
     def set_algorithm(self, algorithm):
         """
-        Set algorithm for config osmo.
+        Set algorithm for configuration of osmo.
 
         :param algorithm: Algorithm object.
         :return: Nothing
         """
         self.config.algorithm = algorithm
         self.algorithm = algorithm
+
+    def stop_on_fail(self, value):
+        """
+        Set stop_on_fail value for configuration of osmo.
+
+        :return: Nothing
+        """
+        self.config.stop_on_fail = value
 
     def add_model(self, model):
         """ Add model for osmo """
@@ -71,7 +79,7 @@ class Osmo(object):
         """
         if self.current_test_number == self.tests_in_a_suite:
             return True
-        elif self.config.stop_on_failure and self.failed_tests:
+        elif self.config.stop_on_fail and self.failed_tests:
             return True
         return False
 
@@ -92,7 +100,8 @@ class Osmo(object):
             try:
                 for _ in range(self.steps_in_a_test):
                     # Use algorithm to select the step
-                    ending = self.algorithm.choose(self.history, self.model.get_list_of_available_steps())
+                    ending = self.algorithm.choose(self.history,
+                                                   self.model.get_list_of_available_steps())
                     self.model.execute_optional('pre_{}'.format(ending))
                     self._execute_step(ending)
                     self.model.execute_optional('post_{}'.format(ending))

--- a/pyosmo/osmo.py
+++ b/pyosmo/osmo.py
@@ -14,14 +14,10 @@ class Osmo(object):
         self.model = Model()
         self.model.add_model(model)
         self.history = OsmoHistory()
-        self.config = OsmoConfig()
-        self.tests_in_a_suite = 10
-        self.steps_in_a_test = 10
+        self._config = OsmoConfig()
         self.current_test_number = 0
         self.failed_tests = 0
         self.debug = False
-        # Use random as default algorithm
-        self.algorithm = self.config.algorithm
 
         if seed is None:
             self.seed = random.randint(0, 10000)
@@ -38,6 +34,16 @@ class Osmo(object):
     def set_debug(self, debug):
         self.debug = debug
 
+    @property
+    def config(self):
+        return self._config
+
+    @config.setter
+    def config(self, value):
+        if not isinstance(value, OsmoConfig):
+            raise AttributeError("config needs to be OsmoConfig.")
+        self._config = value
+
     def set_algorithm(self, algorithm):
         """
         Set algorithm for configuration of osmo.
@@ -45,24 +51,57 @@ class Osmo(object):
         :param algorithm: Algorithm object.
         :return: Nothing
         """
-        self.config.algorithm = algorithm
-        self.algorithm = algorithm
+        self._config.algorithm = algorithm
 
-    def stop_on_fail(self, value):
+    @property
+    def algorithm(self):
+        return self._config.algorithm
+
+    @algorithm.setter
+    def algorithm(self, value):
+        self._config.algorithm = value
+
+    @property
+    def tests_in_a_suite(self):
+        return self._config.tests_in_a_suite
+
+    @tests_in_a_suite.setter
+    def tests_in_a_suite(self, value):
+        self._config.tests_in_a_suite = value
+
+    @property
+    def steps_in_a_test(self):
+        return self._config.steps_in_a_test
+
+    @steps_in_a_test.setter
+    def steps_in_a_test(self, value):
+        self._config.steps_in_a_test = value
+
+    @property
+    def stop_on_fail(self):
         """
         Set stop_on_fail value for configuration of osmo.
 
         :return: Nothing
         """
-        self.config.stop_on_fail = value
+        return self._config.stop_on_fail
 
-    def stop_test_on_exception(self, value):
+    @stop_on_fail.setter
+    def stop_on_fail(self, value):
+        self._config.stop_on_fail = value
+
+    @property
+    def stop_test_on_exception(self):
         """
         Set stop_test_on_exception for configuration of osmo.
 
         :return: Nothing
         """
-        self.config.stop_test_on_exception = value
+        return self._config.stop_test_on_exception
+
+    @stop_test_on_exception.setter
+    def stop_test_on_exception(self, value):
+        self._config.stop_test_on_exception = value
 
     def add_model(self, model):
         """ Add model for osmo """
@@ -87,7 +126,7 @@ class Osmo(object):
         """
         if self.current_test_number == self.tests_in_a_suite:
             return True
-        elif self.config.stop_on_fail and self.failed_tests:
+        elif self.stop_on_fail and self.failed_tests:
             return True
         return False
 
@@ -120,7 +159,7 @@ class Osmo(object):
                 except Exception as error:
                     self.p(error)
                     self.failed_tests += 1
-                    if self.config.stop_test_on_exception:
+                    if self.stop_test_on_exception:
                         self.p("Step {} raised an exception. Stopping this test.".format(ending))
                         break
                 self.model.execute_optional('post_{}'.format(ending))

--- a/pyosmo/tests/test_config.py
+++ b/pyosmo/tests/test_config.py
@@ -3,6 +3,7 @@
 from pyosmo.config import OsmoConfig
 from pyosmo.osmo import Osmo
 
+
 class TestModel(object):
     def __init__(self):
         self.index = 0
@@ -18,8 +19,8 @@ def test_set_configs():
     osmo = Osmo(model)
     assert osmo.config.stop_test_on_exception is True
     assert osmo.config.stop_on_fail is True
-    osmo.stop_on_fail(False)
-    osmo.stop_test_on_exception(False)
+    osmo.stop_on_fail = False
+    osmo.stop_test_on_exception = False
     assert osmo.config.stop_test_on_exception is False
     assert osmo.config.stop_on_fail is False
 
@@ -43,7 +44,7 @@ def test_configs_effects():
     assert model.index == 5
     model.index = 0
     osmo.current_test_number = 0
-    osmo.stop_on_fail(False)
-    osmo.stop_test_on_exception(False)
+    osmo.stop_on_fail = False
+    osmo.stop_test_on_exception = False
     osmo.generate()
     assert model.index == 8

--- a/pyosmo/tests/test_config.py
+++ b/pyosmo/tests/test_config.py
@@ -1,0 +1,49 @@
+# pylint: disable=no-self-use
+
+from pyosmo.config import OsmoConfig
+from pyosmo.osmo import Osmo
+
+class TestModel(object):
+    def __init__(self):
+        self.index = 0
+
+    def step_one(self):
+        self.index += 1
+        if self.index == 5:
+            raise Exception("Should happen!")
+
+
+def test_set_configs():
+    model = TestModel()
+    osmo = Osmo(model)
+    assert osmo.config.stop_test_on_exception is True
+    assert osmo.config.stop_on_fail is True
+    osmo.stop_on_fail(False)
+    osmo.stop_test_on_exception(False)
+    assert osmo.config.stop_test_on_exception is False
+    assert osmo.config.stop_on_fail is False
+
+
+def test_config_object():
+    cfg = OsmoConfig()
+    assert cfg.stop_test_on_exception
+    assert cfg.stop_on_fail
+    cfg.stop_on_fail = False
+    cfg.stop_test_on_exception = False
+    assert cfg.stop_test_on_exception is False
+    assert cfg.stop_on_fail is False
+
+
+def test_configs_effects():
+    model = TestModel()
+    osmo = Osmo(model)
+    osmo.steps_in_a_test = 8
+    osmo.tests_in_a_suite = 1
+    osmo.generate()
+    assert model.index == 5
+    model.index = 0
+    osmo.current_test_number = 0
+    osmo.stop_on_fail(False)
+    osmo.stop_test_on_exception(False)
+    osmo.generate()
+    assert model.index == 8


### PR DESCRIPTION
Configuration object allows to configure stopping generation when either a separate step fails or returns False. Also allows continuing with the test in case one step fails. 